### PR TITLE
Add new connectivity check flag ICE_STUN_REQUEST_NOMINATION_FLAG

### DIFF
--- a/source/ice_api_private.c
+++ b/source/ice_api_private.c
@@ -538,41 +538,42 @@ IceHandleStunPacketResult_t Ice_HandleStunBindingRequest( IceContext_t * pContex
                     pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_REQUEST_NOMINATION_FLAG;
                     pIceCandidatePair->state = ICE_CANDIDATE_PAIR_STATE_NOMINATED;
                 }
-
-                /* Is the entire handshaking process and nomination completed. */
-                if( ICE_STUN_CONNECTIVITY_CHECK_SUCCESSFUL( pIceCandidatePair->connectivityCheckFlags ) )
-                {
-                    handleStunPacketResult = ICE_HANDLE_STUN_PACKET_RESULT_SEND_RESPONSE_FOR_NOMINATION;
-                }
             }
-
-            /* Received a connectivity check request from the remote candidate. */
-            if( ( pIceCandidatePair->connectivityCheckFlags & ICE_STUN_REQUEST_RECEIVED_FLAG ) == 0 )
+            /* Is the entire handshaking process and nomination completed. */
+            if( ICE_STUN_CONNECTIVITY_CHECK_SUCCESSFUL( pIceCandidatePair->connectivityCheckFlags ) )
             {
-                pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_REQUEST_RECEIVED_FLAG;
-            }
-
-            if( ( pIceCandidatePair->connectivityCheckFlags & ICE_STUN_REQUEST_SENT_FLAG ) == 0 )
-            {
-                /* We have not sent the connectivity check request to this
-                 * candidate. The application needs to send 2 stun packets-
-                 * 1. The connectivity check request from local to remote.
-                 * 2. The response to the connectivity check request
-                 *    received from remote. */
-                pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_REQUEST_SENT_FLAG;
-                pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_RESPONSE_SENT_FLAG;
-
-                handleStunPacketResult = ICE_HANDLE_STUN_PACKET_RESULT_SEND_TRIGGERED_CHECK;
+                handleStunPacketResult = ICE_HANDLE_STUN_PACKET_RESULT_SEND_RESPONSE_FOR_NOMINATION;
             }
             else
             {
-                    /* We have sent the connectivity check request to this
-                    * candidate. The application needs to send 1 stun packet-
-                    * 1. The response to the connectivity check request
-                    *    received from remote. */
-                pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_RESPONSE_SENT_FLAG;
+                /* Received a connectivity check request from the remote candidate. */
+                if( ( pIceCandidatePair->connectivityCheckFlags & ICE_STUN_REQUEST_RECEIVED_FLAG ) == 0 )
+                {
+                    pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_REQUEST_RECEIVED_FLAG;
+                }
 
-                handleStunPacketResult = ICE_HANDLE_STUN_PACKET_RESULT_SEND_RESPONSE_FOR_REMOTE_REQUEST;
+                if( ( pIceCandidatePair->connectivityCheckFlags & ICE_STUN_REQUEST_SENT_FLAG ) == 0 )
+                {
+                    /* We have not sent the connectivity check request to this
+                    * candidate. The application needs to send 2 stun packets-
+                    * 1. The connectivity check request from local to remote.
+                    * 2. The response to the connectivity check request
+                    *    received from remote. */
+                    pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_REQUEST_SENT_FLAG;
+                    pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_RESPONSE_SENT_FLAG;
+
+                    handleStunPacketResult = ICE_HANDLE_STUN_PACKET_RESULT_SEND_TRIGGERED_CHECK;
+                }
+                else
+                {
+                        /* We have sent the connectivity check request to this
+                        * candidate. The application needs to send 1 stun packet-
+                        * 1. The response to the connectivity check request
+                        *    received from remote. */
+                    pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_RESPONSE_SENT_FLAG;
+
+                    handleStunPacketResult = ICE_HANDLE_STUN_PACKET_RESULT_SEND_RESPONSE_FOR_REMOTE_REQUEST;
+                }
             }
         }
         else

--- a/source/ice_api_private.c
+++ b/source/ice_api_private.c
@@ -531,39 +531,48 @@ IceHandleStunPacketResult_t Ice_HandleStunBindingRequest( IceContext_t * pContex
         if( pIceCandidatePair != NULL )
         {
             /* Did we receive a request for nomination? */
-            if( ( deserializePacketInfo.useCandidateFlag == 1 ) &&
-                ICE_STUN_CONNECTIVITY_CHECK_SUCCESSFUL( pIceCandidatePair->connectivityCheckFlags ) )
+            if( deserializePacketInfo.useCandidateFlag == 1 )
             {
-                pIceCandidatePair->state = ICE_CANDIDATE_PAIR_STATE_NOMINATED;
-                handleStunPacketResult = ICE_HANDLE_STUN_PACKET_RESULT_SEND_RESPONSE_FOR_NOMINATION;
+                if( ( pIceCandidatePair->connectivityCheckFlags & ICE_STUN_REQUEST_NOMINATION_FLAG ) == 0 )
+                {
+                    pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_REQUEST_NOMINATION_FLAG;
+                    pIceCandidatePair->state = ICE_CANDIDATE_PAIR_STATE_NOMINATED;
+                }
+
+                /* Is the entire handshaking process and nomination completed. */
+                if( ICE_STUN_CONNECTIVITY_CHECK_SUCCESSFUL( pIceCandidatePair->connectivityCheckFlags ) )
+                {
+                    handleStunPacketResult = ICE_HANDLE_STUN_PACKET_RESULT_SEND_RESPONSE_FOR_NOMINATION;
+                }
+            }
+
+            /* Received a connectivity check request from the remote candidate. */
+            if( ( pIceCandidatePair->connectivityCheckFlags & ICE_STUN_REQUEST_RECEIVED_FLAG ) == 0 )
+            {
+                pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_REQUEST_RECEIVED_FLAG;
+            }
+
+            if( ( pIceCandidatePair->connectivityCheckFlags & ICE_STUN_REQUEST_SENT_FLAG ) == 0 )
+            {
+                /* We have not sent the connectivity check request to this
+                 * candidate. The application needs to send 2 stun packets-
+                 * 1. The connectivity check request from local to remote.
+                 * 2. The response to the connectivity check request
+                 *    received from remote. */
+                pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_REQUEST_SENT_FLAG;
+                pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_RESPONSE_SENT_FLAG;
+
+                handleStunPacketResult = ICE_HANDLE_STUN_PACKET_RESULT_SEND_TRIGGERED_CHECK;
             }
             else
             {
-                /* Received a connectivity check request from the remote candidate. */
-                pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_REQUEST_RECEIVED_FLAG;
+                    /* We have sent the connectivity check request to this
+                    * candidate. The application needs to send 1 stun packet-
+                    * 1. The response to the connectivity check request
+                    *    received from remote. */
+                pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_RESPONSE_SENT_FLAG;
 
-                if( ( pIceCandidatePair->connectivityCheckFlags & ICE_STUN_REQUEST_SENT_FLAG ) == 0 )
-                {
-                    /* We have not sent the connectivity check request to this
-                     * candidate. The application needs to send 2 stun packets-
-                     * 1. The connectivity check request from local to remote.
-                     * 2. The response to the connectivity check request
-                     *    received from remote. */
-                    pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_REQUEST_SENT_FLAG;
-                    pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_RESPONSE_SENT_FLAG;
-
-                    handleStunPacketResult = ICE_HANDLE_STUN_PACKET_RESULT_SEND_TRIGGERED_CHECK;
-                }
-                else
-                {
-                     /* We have sent the connectivity check request to this
-                      * candidate. The application needs to send 1 stun packet-
-                      * 1. The response to the connectivity check request
-                      *    received from remote. */
-                    pIceCandidatePair->connectivityCheckFlags |= ICE_STUN_RESPONSE_SENT_FLAG;
-
-                    handleStunPacketResult = ICE_HANDLE_STUN_PACKET_RESULT_SEND_RESPONSE_FOR_REMOTE_REQUEST;
-                }
+                handleStunPacketResult = ICE_HANDLE_STUN_PACKET_RESULT_SEND_RESPONSE_FOR_REMOTE_REQUEST;
             }
         }
         else

--- a/source/include/ice_data_types.h
+++ b/source/include/ice_data_types.h
@@ -14,16 +14,18 @@
 /*----------------------------------------------------------------------------*/
 
 /* Macros used to track a candidate pair's connectivity check status. */
-#define ICE_STUN_REQUEST_SENT_FLAG      ( 1 << 0 )
-#define ICE_STUN_RESPONSE_RECEIVED_FLAG ( 1 << 1 )
-#define ICE_STUN_REQUEST_RECEIVED_FLAG  ( 1 << 2 )
-#define ICE_STUN_RESPONSE_SENT_FLAG     ( 1 << 3 )
+#define ICE_STUN_REQUEST_SENT_FLAG          ( 1 << 0 )
+#define ICE_STUN_RESPONSE_RECEIVED_FLAG     ( 1 << 1 )
+#define ICE_STUN_REQUEST_RECEIVED_FLAG      ( 1 << 2 )
+#define ICE_STUN_RESPONSE_SENT_FLAG         ( 1 << 3 )
+#define ICE_STUN_REQUEST_NOMINATION_FLAG    ( 1 << 4 )
 
 #define ICE_STUN_CONNECTIVITY_CHECK_SUCCESSFUL( connectivityCheckFlags )    \
     ( ( connectivityCheckFlags ) == ( ICE_STUN_REQUEST_SENT_FLAG |          \
                                       ICE_STUN_RESPONSE_RECEIVED_FLAG |     \
                                       ICE_STUN_REQUEST_RECEIVED_FLAG |      \
-                                      ICE_STUN_RESPONSE_SENT_FLAG ) )
+                                      ICE_STUN_RESPONSE_SENT_FLAG |         \
+                                      ICE_STUN_REQUEST_NOMINATION_FLAG ) )
 
 /*----------------------------------------------------------------------------*/
 


### PR DESCRIPTION
*Issue #, if available:*
The FreeRTOS application was failing in FireFox, because FireFox sends connectivity check requests from remote with the `USE_CANDIDATE` attribute always set. As a result, the peer connection is never successful.

*Description of changes:*
This PR introduces a new connectivity check flag `ICE_STUN_REQUEST_NOMINATION_FLAG` to handle the issue described above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
