### PR TITLE
Add nominated state check

### DIFF
--- a/source/ice_api_private.c
+++ b/source/ice_api_private.c
@@ -532,8 +532,10 @@ IceHandleStunPacketResult_t Ice_HandleStunBindingRequest( IceContext_t * pContex
 
         if( pIceCandidatePair != NULL )
         {
-            /* Did we receive a request for nomination? */
-            if( deserializePacketInfo.useCandidateFlag == 1 )
+            /* Did we receive a request for nomination and the candidate pair is
+             * not already nominated? */
+            if( ( deserializePacketInfo.useCandidateFlag == 1 ) &&
+                ( pIceCandidatePair->state != ICE_CANDIDATE_PAIR_STATE_NOMINATED ) )
             {
                 pIceCandidatePair->state = ICE_CANDIDATE_PAIR_STATE_NOMINATED;
 


### PR DESCRIPTION
## Description
It is possible to get STUN binding requests with USE_CANDIDATE flag set even after the nomination is complete. Such requests need to be treated as normal connectivity check requests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
