### PR TITLE
Use a bit in candidate pair to know if that pair is succeeded.

### DIFF
--- a/source/ice_api_private.c
+++ b/source/ice_api_private.c
@@ -1758,7 +1758,7 @@ IceHandleStunPacketResult_t Ice_HandleConnectivityCheckResponse( IceContext_t * 
                 if( pIceCandidatePair->state == ICE_CANDIDATE_PAIR_STATE_NOMINATED )
                 {
                     pIceCandidatePair->state = ICE_CANDIDATE_PAIR_STATE_SUCCEEDED;
-                    pContext->pSelectedPair = pIceCandidatePair;
+                    pIceCandidatePair->succeeded = 1U;
                     handleStunPacketResult = ICE_HANDLE_STUN_PACKET_RESULT_CANDIDATE_PAIR_READY;
                 }
                 else
@@ -1778,7 +1778,7 @@ IceHandleStunPacketResult_t Ice_HandleConnectivityCheckResponse( IceContext_t * 
                 if( pIceCandidatePair->state == ICE_CANDIDATE_PAIR_STATE_NOMINATED )
                 {
                     pIceCandidatePair->state = ICE_CANDIDATE_PAIR_STATE_SUCCEEDED;
-                    pContext->pSelectedPair = pIceCandidatePair;
+                    pIceCandidatePair->succeeded = 1U;
                     handleStunPacketResult = ICE_HANDLE_STUN_PACKET_RESULT_CANDIDATE_PAIR_READY;
                 }
                 else
@@ -2266,7 +2266,7 @@ IceHandleStunPacketResult_t Ice_HandleTurnChannelBindSuccessResponse( IceContext
         /* If the candidate pair is already selected, the application need not
          * take any action. Otherwise, the application need to initiate
          * connectivity check. */
-        if( pContext->pSelectedPair == pIceCandidatePair )
+        if( pIceCandidatePair->succeeded != 0U )
         {
             pIceCandidatePair->state = ICE_CANDIDATE_PAIR_STATE_SUCCEEDED;
             handleStunPacketResult = ICE_HANDLE_STUN_PACKET_RESULT_FRESH_CHANNEL_BIND_COMPLETE;

--- a/source/include/ice_data_types.h
+++ b/source/include/ice_data_types.h
@@ -266,6 +266,7 @@ typedef struct IceCandidatePair
     IceCandidate_t * pRemoteCandidate;
     uint64_t priority;
     IceCandidatePairState_t state;
+    uint8_t succeeded;
     uint32_t connectivityCheckFlags;
     uint8_t transactionId[ STUN_HEADER_TRANSACTION_ID_LENGTH ];
 
@@ -312,7 +313,6 @@ typedef struct IceContext
     size_t maxTurnServers;
     size_t numTurnServers;
     IceCandidatePair_t * pNominatedPair;
-    IceCandidatePair_t * pSelectedPair;
     uint64_t tieBreaker;
     uint8_t isControlling;
     TransactionIdStore_t * pStunBindingRequestTransactionIdStore;


### PR DESCRIPTION
*Issue #, if available:*
We might have multiple succeeded candidate pair. Use a bit in candidate pair structure to know if that pair is succeeded for refreshing TURN connection for create permission/channel binding timeout.

*Description of changes:*
Use a bit in candidate pair to know if that pair is succeeded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
